### PR TITLE
Fix build warnings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,16 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
+    ksp {
+        arg("room.incremental", "true")
+        // TODO uncomment once we have the first valid version of DB
+        // arg("room.schemaLocation", "$projectDir/schemas")
+    }
+
+    hilt {
+        enableAggregatingTask = true
+    }
 }
 
 dependencies {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,7 +55,6 @@ android {
     }
 
     ksp {
-        arg("room.incremental", "true")
         // TODO uncomment once we have the first valid version of DB
         // arg("room.schemaLocation", "$projectDir/schemas")
     }

--- a/app/src/main/java/com/sebastianvm/mango/database/MangoDatabase.kt
+++ b/app/src/main/java/com/sebastianvm/mango/database/MangoDatabase.kt
@@ -12,7 +12,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 
-@Database(entities = [JobEntity::class], version = 1)
+@Database(entities = [JobEntity::class], version = 1, exportSchema = false)
 abstract class MangoDatabase : RoomDatabase() {
     abstract fun jobDao(): JobDao
 }

--- a/app/src/main/java/com/sebastianvm/mango/ui/example/ExampleNavDestination.kt
+++ b/app/src/main/java/com/sebastianvm/mango/ui/example/ExampleNavDestination.kt
@@ -6,6 +6,7 @@ import com.sebastianvm.mango.ui.navigation.DestinationType
 import com.sebastianvm.mango.ui.navigation.NavigationRoute
 import com.sebastianvm.mango.ui.navigation.screenDestination
 
+@Suppress("UNUSED_PARAMETER")
 fun NavGraphBuilder.exampleNavDestination(navController: NavController) {
     screenDestination<ExampleViewModel>(
         destination = NavigationRoute.Example,

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+kapt.incremental.apt=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,5 +21,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-
-kapt.incremental.apt=true


### PR DESCRIPTION
Fix some build warnings. Will annotate on the lines themselves.
Let's try to keep warnings to 0 so as to minimize noise in builds, and more easily parse+fix warnings in the future.