### PR TITLE
introduce vmScope for tests

### DIFF
--- a/app/src/main/java/com/sebastianvm/mango/ui/mvvm/BaseViewModel.kt
+++ b/app/src/main/java/com/sebastianvm/mango/ui/mvvm/BaseViewModel.kt
@@ -1,6 +1,7 @@
 package com.sebastianvm.mango.ui.mvvm
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -9,10 +10,13 @@ interface State
 interface UserAction
 
 abstract class BaseViewModel<S : State, A : UserAction>(
-    initialState: S
+    initialState: S,
 ) : ViewModel() {
     private val _state = MutableStateFlow(initialState)
     val state: StateFlow<S> = _state
+
+    // In tests, vmScope should be set to an instance of TestScope
+    var vmScope = viewModelScope
 
     abstract fun handle(action: A)
 


### PR DESCRIPTION
Title. We might want to write a ktlint rule for preveting usages of `viewModelScope`. Opted to go this easier route so as not to deal with Hilt and having to create this parameter on every viewModel