### PR TITLE
Generate test files for fakes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,7 +92,7 @@ dependencies {
     implementation(libs.kotlinx.datetime)
 
     implementation(project(":fakegen"))
-    kspDebug(project(":fakegen"))
+    kspTest(project(":fakegen"))
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)
     testImplementation(libs.junit.jupiter)

--- a/app/src/test/java/com/sebastianvm/mango/FakeProvider.kt
+++ b/app/src/test/java/com/sebastianvm/mango/FakeProvider.kt
@@ -1,7 +1,7 @@
 package com.sebastianvm.mango
 
-import com.sebastianvm.mango.data.FakeIncomeSourceRepository
-import com.sebastianvm.mango.database.dao.FakeIncomeSourceDao
+import com.sebastianvm.mango.data.FakeIncomeSourceRepositoryImpl
+import com.sebastianvm.mango.database.dao.FakeIncomeSourceDaoImpl
 import com.sebastianvm.mango.database.models.IncomeSourceEntity
 import kotlinx.coroutines.flow.MutableStateFlow
 import java.util.stream.Stream
@@ -10,14 +10,14 @@ object FakeProvider {
 
     val defaultIncomeSourceEntity = IncomeSourceEntity(id = 0, name = "")
 
-    val incomeSourceDao: FakeIncomeSourceDao
-        get() = FakeIncomeSourceDao(
+    val incomeSourceDao: FakeIncomeSourceDaoImpl
+        get() = FakeIncomeSourceDaoImpl(
             getIncomeSourceValue = MutableStateFlow(defaultIncomeSourceEntity),
             getAllIncomeSourcesValue = MutableStateFlow(listOf(defaultIncomeSourceEntity))
         )
 
-    val incomeSourceRepository: FakeIncomeSourceRepository
-        get() = FakeIncomeSourceRepository(
+    val incomeSourceRepository: FakeIncomeSourceRepositoryImpl
+        get() = FakeIncomeSourceRepositoryImpl(
             getIncomeSourceValue = MutableStateFlow(defaultIncomeSourceEntity),
             getAllIncomeSourcesValue = MutableStateFlow(listOf(defaultIncomeSourceEntity))
         )

--- a/app/src/test/java/com/sebastianvm/mango/data/FakeIncomeSourceRepository.kt
+++ b/app/src/test/java/com/sebastianvm/mango/data/FakeIncomeSourceRepository.kt
@@ -1,0 +1,6 @@
+package com.sebastianvm.mango.data
+
+import com.sebastianvm.fakegen.FakeClass
+
+@FakeClass
+interface FakeIncomeSourceRepository : IncomeSourceRepository

--- a/app/src/test/java/com/sebastianvm/mango/data/IncomeSourceRepositoryImplTest.kt
+++ b/app/src/test/java/com/sebastianvm/mango/data/IncomeSourceRepositoryImplTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.sebastianvm.mango.BaseTest
 import com.sebastianvm.mango.FakeProvider
 import com.sebastianvm.mango.database.dao.FakeIncomeSourceDao
+import com.sebastianvm.mango.database.dao.FakeIncomeSourceDaoImpl
 import com.sebastianvm.mango.database.models.IncomeSourceEntity
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -14,7 +15,7 @@ import org.junit.jupiter.params.provider.MethodSource
 
 class IncomeSourceRepositoryImplTest : BaseTest() {
 
-    private lateinit var incomeSourceDao: FakeIncomeSourceDao
+    private lateinit var incomeSourceDao: FakeIncomeSourceDaoImpl
 
     @BeforeEach
     fun beforeEach() {

--- a/app/src/test/java/com/sebastianvm/mango/database/dao/FakeIncomeSourceDao.kt
+++ b/app/src/test/java/com/sebastianvm/mango/database/dao/FakeIncomeSourceDao.kt
@@ -1,0 +1,6 @@
+package com.sebastianvm.mango.database.dao
+
+import com.sebastianvm.fakegen.FakeClass
+
+@FakeClass
+interface FakeIncomeSourceDao : IncomeSourceDao

--- a/app/src/test/java/com/sebastianvm/mango/ui/example/ExampleViewModelTest.kt
+++ b/app/src/test/java/com/sebastianvm/mango/ui/example/ExampleViewModelTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.sebastianvm.mango.BaseTest
 import com.sebastianvm.mango.FakeProvider
 import com.sebastianvm.mango.data.FakeIncomeSourceRepository
+import com.sebastianvm.mango.data.FakeIncomeSourceRepositoryImpl
 import com.sebastianvm.mango.database.models.IncomeSourceEntity
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -13,7 +14,7 @@ import org.junit.jupiter.params.provider.MethodSource
 
 class ExampleViewModelTest : BaseTest() {
 
-    private lateinit var incomeSourceRepository: FakeIncomeSourceRepository
+    private lateinit var incomeSourceRepository: FakeIncomeSourceRepositoryImpl
 
     @BeforeEach
     fun beforeEach() {


### PR DESCRIPTION
The reason we cannot create files in the test sources is because KSP does not have access to the main sources if we use `kspTest`. A workaround is adding files to test sources that we can use for code generartion. Lmk what you think - we can also keep the current approach.
