### PR TITLE
refactored Tax model

### DIFF
--- a/app/src/main/java/com/sebastianvm/mango/database/models/TaxEntity.kt
+++ b/app/src/main/java/com/sebastianvm/mango/database/models/TaxEntity.kt
@@ -1,16 +1,15 @@
 package com.sebastianvm.mango.database.models
 
 import androidx.room.Entity
-import androidx.room.PrimaryKey
 import com.sebastianvm.mango.model.Deduction
 import com.sebastianvm.mango.model.Jurisdiction
 import com.sebastianvm.mango.model.Tax
 import com.sebastianvm.mango.model.TaxType
 
-@Entity
+@Entity(primaryKeys = ["name", "year"])
 data class TaxEntity(
-    @PrimaryKey(autoGenerate = true) override val id: Long,
     override val name: String,
+    override val year: Int,
     override val jurisdiction: Jurisdiction,
     override val taxType: TaxType,
     override val deductions: List<Deduction>

--- a/app/src/main/java/com/sebastianvm/mango/model/Tax.kt
+++ b/app/src/main/java/com/sebastianvm/mango/model/Tax.kt
@@ -1,7 +1,7 @@
 package com.sebastianvm.mango.model
 
 interface Tax {
-    val id: Long
+    val year: Int
     val name: String
     val jurisdiction: Jurisdiction
     val taxType: TaxType


### PR DESCRIPTION
Removed the ID property and added year property. The primary keys will be both the year and the property. This should be fine since we will be hardcoding these. This also makes it easier to set relationship by name, enforcing only one tax per year per name, which allows us to easily have multiple copies of the same tax for different years.
